### PR TITLE
Set Thread.IsBackground to true

### DIFF
--- a/EEPhysics/PhysicsWorld.cs
+++ b/EEPhysics/PhysicsWorld.cs
@@ -411,7 +411,7 @@ namespace EEPhysics
             {
                 if (inited)
                 {
-                    physicsThread = new Thread(new ThreadStart(Run));
+                    physicsThread = new Thread(Run) {IsBackground = true};
                     physicsThread.Start();
                 }
                 else


### PR DESCRIPTION
Thread.IsBackground should be set to true, otherwise, when the console
app tries to exit, it can't because the physicsThread would be blocking
the app exit. (.NET AppDomains only exit once the last non-background
thread exits)