### PR TITLE
Small fixes, implement IDisposable.

### DIFF
--- a/EEPhysics/PhysicsPlayer.cs
+++ b/EEPhysics/PhysicsPlayer.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using PlayerIOClient;
 
 namespace EEPhysics
 {
@@ -228,7 +225,7 @@ namespace EEPhysics
                         break;
                     default:
                         morx = 0;
-                        mory = (int)gravity;
+                        mory = gravity;
                         break;
                 }
 
@@ -681,7 +678,7 @@ namespace EEPhysics
                             else
                             {
                                 X -= tx / 15;
-                            };
+                            }
                         }
                         else
                         {

--- a/EEPhysics/PhysicsWorld.cs
+++ b/EEPhysics/PhysicsWorld.cs
@@ -598,7 +598,7 @@ namespace EEPhysics
                             case 83:
                             case 77:
                                 continue;
-                        };
+                        }
                         return true;
                     }
                 }
@@ -615,7 +615,7 @@ namespace EEPhysics
         internal static string Derot(string arg1)
         {
             // by Capasha (http://pastebin.com/Pj6tvNNx)
-            int num = 0;
+            int num;
             string str = "";
             for (int i = 0; i < arg1.Length; i++)
             {
@@ -692,7 +692,7 @@ namespace EEPhysics
                             }
                             break;
                     }
-                    int x = 0, y = 0;
+                    int x, y;
 
                     for (int pos = 0; pos < ya.Length; pos += 2)
                     {

--- a/EEPhysics/PhysicsWorld.cs
+++ b/EEPhysics/PhysicsWorld.cs
@@ -9,7 +9,7 @@ using PlayerIOClient;
 
 namespace EEPhysics
 {
-    public class PhysicsWorld
+    public class PhysicsWorld : IDisposable 
     {
         internal const int Size = 16;
         internal Stopwatch sw = new Stopwatch();
@@ -711,6 +711,11 @@ namespace EEPhysics
             {
                 Debug.WriteLine(" EEPhysics: Error loading existing blocks:\n" + e);
             }
+        }
+
+        void IDisposable.Dispose()
+        {
+            StopSimulation();
         }
     }
 }

--- a/EEPhysics/PhysicsWorld.cs
+++ b/EEPhysics/PhysicsWorld.cs
@@ -361,13 +361,13 @@ namespace EEPhysics
         }
         /// <param name="z">Block layer: 0 = foreground, 1 = background</param>
         /// <param name="x">Block X</param>
-        /// <param name="z">Block Y</param>
+        /// <param name="y">Block Y</param>
         /// <returns>Block ID</returns>
         public int GetBlock(int z, int x, int y)
         {
             if (z < 0 || z > 1)
             {
-                throw new ArgumentOutOfRangeException("zz", "Layer must be 0 (foreground) or 1 (background).");
+                throw new ArgumentOutOfRangeException("z", "Layer must be 0 (foreground) or 1 (background).");
             }
             if (x < 0 || x >= WorldWidth || y < 0 || y >= WorldHeight)
             {
@@ -690,8 +690,6 @@ namespace EEPhysics
                                 data.Add(m.GetInteger(messageIndex));
                                 messageIndex++;
                             }
-                            break;
-                        default:
                             break;
                     }
                     int x = 0, y = 0;


### PR DESCRIPTION
IDisposable implementation allows the usage of the "using" keyword plus
many other benefits such as the ability to support auto-disposal
patterns. (Note: This does not add a "Dispose()" function to
PhysicsWorld, since there is already StopSimulation(). Dispose can only
be called when PhysicsWorld is cast to IDisposable